### PR TITLE
fix: Listens for formatHitURL changes

### DIFF
--- a/src/AlgoliaSearch/elements/ResultsList/index.js
+++ b/src/AlgoliaSearch/elements/ResultsList/index.js
@@ -24,10 +24,10 @@ const ResultsList = (props) => {
       appendNewSectionLength(sectionIndex, 0);
     }
   }, [hits.length]); // eslint-disable-line
-  
+
   const formattedHitURL = useCallback((hit) => {
     return formatHitURL(hit)
-  }, []);
+  }, [formatHitURL]);
 
   if ((Array.isArray(hits) && hits.length > 0) && !shouldHideResults) {
     return (


### PR DESCRIPTION
Fixes https://github.com/Maxihost/control-next/pull/263
AlgoliaSearch needs to listen for formatHitURL prop changes so it can show the most updated data.