### PR TITLE
Sidesheet Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.3.1](https://github.com/Maxihost/metal-ui/compare/v2.3.0...v2.3.1) (2021-02-26)
+
+
+### Bug Fixes
+
+* Builds dist ([52375e3](https://github.com/Maxihost/metal-ui/commit/52375e31dccf5f753d86981e58623ad8a10035dd))
+
 # [2.3.0](https://github.com/Maxihost/metal-ui/compare/v2.2.2...v2.3.0) (2021-02-26)
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -7676,7 +7676,7 @@ var Sidesheet_Sidesheet = function Sidesheet(_ref2) {
   }, [isShown]);
 
   var closeTransition = function closeTransition() {
-    if (isOpened) {
+    if (isOpened && transition) {
       onClose();
       setTransition(false);
       setTimeout(function () {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7694,7 +7694,7 @@ var Sidesheet_Sidesheet = function Sidesheet(_ref2) {
     onClick: function onClick() {
       return closeTransition();
     },
-    className: bind_default()("fixed z-40 inset-0 opacity-25 duration-300 delay-200 transition", {
+    className: bind_default()("fixed z-50 inset-0 opacity-25 duration-300 delay-200 transition", {
       "bg-gray-800": transition,
       "bg-transparent": !transition
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxihost/metal-ui",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxihost/metal-ui",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Metal UI Design System",
   "main": "dist/index.js",
   "files": [

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -72,7 +72,7 @@ const Sidesheet = ({
   }, [isShown]);
 
   const closeTransition = () => {
-    if (isOpened) {
+    if (isOpened && transition) {
       onClose();
       setTransition(false);
       setTimeout(() => setIsOpened(false), 500);

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -90,7 +90,7 @@ const Sidesheet = ({
           <div
             onClick={() => closeTransition()}
             className={classNames(
-              "fixed z-40 inset-0 opacity-25 duration-300 delay-200 transition",
+              "fixed z-50 inset-0 opacity-25 duration-300 delay-200 transition",
               {
                 "bg-gray-800": transition,
                 "bg-transparent": !transition,


### PR DESCRIPTION
This PR fixes the Sidesheet stuck in blocked state, not opening anymore - https://c.maxi.host/BluYYA41

The way it could get reproduced is if you:
1. Opened the Sidesheet
2. Closed the Sidesheet + opened it again in a timeframe of 500ms

It now also checks that an open transition is not happening in the meantime and from locally linking Control, the bug cannot be reproduced anymore.

I've also included a z-index fix for the Sidesheet where elements that should be underneath the overlay appeared on top:
**Before**
https://user-images.githubusercontent.com/11167320/109563032-e56b9880-7ae7-11eb-82f7-abb15b9a52d6.png
**After**
https://user-images.githubusercontent.com/11167320/109563042-e7355c00-7ae7-11eb-9301-3bd6c727b5bd.png
