### PR TITLE
AlgoliaSearch selectable

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12941,6 +12941,8 @@ function _cleanUp(props, searchState, context) {
 // CONCATENATED MODULE: ./src/AlgoliaSearch/elements/SearchBox/index.js
 function SearchBox_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
+function SearchBox_extends() { SearchBox_extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return SearchBox_extends.apply(this, arguments); }
+
 
 
 
@@ -12959,7 +12961,8 @@ var SearchBox_SearchBox = function SearchBox(props) {
       id = props.id,
       dark = props.dark,
       placeholder = props.placeholder,
-      selectedText = props.selectedText;
+      selectedText = props.selectedText,
+      inputProps = props.inputProps;
 
   var _useTabController = TabController_useTabController(),
       resetActiveElementIndex = _useTabController.resetActiveElementIndex,
@@ -13002,7 +13005,7 @@ var SearchBox_SearchBox = function SearchBox(props) {
     className: "ais-SearchBox-form m-0",
     noValidate: true,
     role: "search"
-  }, emotion_react_browser_esm_jsx(src_Input, SearchBox_defineProperty({
+  }, emotion_react_browser_esm_jsx(src_Input, SearchBox_extends(SearchBox_defineProperty({
     ref: inputRef,
     inputClassName: "".concat((isResultsWindowOpen ? "focused" : "", dark ? "bg-gray-800 border-gray-600 text-white focus:border-gray-500 hover:border-gray-500" : "bg-white border-gray-200 text-gray-900 focus:border-gray-300 hover:border-gray-300"), " -mt-1 ais-SearchBox-input w-full focus:outline-none focus:shadow-none"),
     value: currentRefinement,
@@ -13013,7 +13016,7 @@ var SearchBox_SearchBox = function SearchBox(props) {
     placeholder: "".concat(placeholder ? placeholder : "Search..."),
     id: "search-box-".concat(id),
     autoComplete: "off"
-  }, "type", "search"))));
+  }, "type", "search"), inputProps))));
 };
 
 SearchBox_SearchBox.propTypes = {
@@ -13211,7 +13214,7 @@ var ResultPill_ResultPill = function ResultPill(props) {
     onMouseEnter: handleHoverSelection
   }, emotion_react_browser_esm_jsx("a", {
     ref: clickableLink,
-    href: !onSelect && formattedHitURL,
+    href: !onSelect ? formattedHitURL : null,
     onClick: onSelect,
     className: "px-2 rounded outline-none ".concat(isCurrentElement ? 'bg-indigo-600 text-white' : 'text-gray-800'),
     style: ResultPill_objectSpread({}, ResultPill_style.resultPillLink)
@@ -13313,7 +13316,8 @@ ResultsList_ResultsList.propTypes = {
   sectionTitle: prop_types_default.a.string.isRequired,
   sectionIndex: prop_types_default.a.number.isRequired,
   renderCardInfo: prop_types_default.a.func.isRequired,
-  formatHitURL: prop_types_default.a.func
+  formatHitURL: prop_types_default.a.func,
+  onSelect: prop_types_default.a.func
 };
 /* harmony default export */ var elements_ResultsList = (connectHits(ResultsList_ResultsList));
 // CONCATENATED MODULE: ./src/AlgoliaSearch/assets/ArrowDown/index.js
@@ -13491,7 +13495,8 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
       dark = props.dark,
       placeholder = props.placeholder,
       formatSelected = props.formatSelected,
-      _onSelect = props.onSelect;
+      _onSelect = props.onSelect,
+      inputProps = props.inputProps;
 
   var _useTabController = TabController_useTabController(),
       activeElementIndex = _useTabController.activeElementIndex,
@@ -13703,6 +13708,7 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
     id: ALGOLIA_APP_ID,
     dark: dark,
     selectedText: selectedItem ? formatSelected(selectedItem) : '',
+    inputProps: inputProps,
     placeholder: placeholder
   }), emotion_react_browser_esm_jsx("div", {
     className: "shadow-xl rounded absolute w-full bg-white border border-gray-200",

--- a/dist/index.js
+++ b/dist/index.js
@@ -12958,7 +12958,8 @@ var SearchBox_SearchBox = function SearchBox(props) {
       refine = props.refine,
       id = props.id,
       dark = props.dark,
-      placeholder = props.placeholder;
+      placeholder = props.placeholder,
+      selectedText = props.selectedText;
 
   var _useTabController = TabController_useTabController(),
       resetActiveElementIndex = _useTabController.resetActiveElementIndex,
@@ -12966,7 +12967,12 @@ var SearchBox_SearchBox = function SearchBox(props) {
       setIsResultsWindowOpen = _useTabController.setIsResultsWindowOpen,
       setSearchInputHeight = _useTabController.setSearchInputHeight;
 
+  var inputRef = Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["useRef"])();
   var searchInputRef = Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["useRef"])(null);
+  Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["useEffect"])(function () {
+    refine(selectedText);
+    inputRef.current.value = selectedText || '';
+  }, [selectedText]);
 
   var handleOnChange = function handleOnChange(value, e) {
     if (e.keyCode !== 40 && e.keyCode !== 38) {
@@ -12997,6 +13003,7 @@ var SearchBox_SearchBox = function SearchBox(props) {
     noValidate: true,
     role: "search"
   }, emotion_react_browser_esm_jsx(src_Input, SearchBox_defineProperty({
+    ref: inputRef,
     inputClassName: "".concat((isResultsWindowOpen ? "focused" : "", dark ? "bg-gray-800 border-gray-600 text-white focus:border-gray-500 hover:border-gray-500" : "bg-white border-gray-200 text-gray-900 focus:border-gray-300 hover:border-gray-300"), " -mt-1 ais-SearchBox-input w-full focus:outline-none focus:shadow-none"),
     value: currentRefinement,
     onChange: handleOnChange,
@@ -13012,7 +13019,8 @@ var SearchBox_SearchBox = function SearchBox(props) {
 SearchBox_SearchBox.propTypes = {
   currentRefinement: prop_types_default.a.string.isRequired,
   refine: prop_types_default.a.func.isRequired,
-  id: prop_types_default.a.string.isRequired
+  id: prop_types_default.a.string.isRequired,
+  selectedText: prop_types_default.a.string
 };
 /* harmony default export */ var elements_SearchBox = (connectSearchBox(SearchBox_SearchBox));
 // CONCATENATED MODULE: ./node_modules/react-instantsearch-core/dist/es/connectors/connectHits.js
@@ -13127,7 +13135,8 @@ var ResultPill_ResultPill = function ResultPill(props) {
       elementIndex = props.elementIndex,
       sectionIndex = props.sectionIndex,
       formattedHitURL = props.formattedHitURL,
-      noResults = props.noResults;
+      noResults = props.noResults,
+      onSelect = props.onSelect;
 
   var _useTabController = TabController_useTabController(),
       activeElementIndex = _useTabController.activeElementIndex,
@@ -13149,8 +13158,10 @@ var ResultPill_ResultPill = function ResultPill(props) {
     if (isCurrentElement && enterKeyWasPressed) {
       if (formattedHitURL) {
         clickableLink.current.click();
+      } else if (onSelect) {
+        onSelect();
       } else {
-        alert('The formattedHitURL prop was not found, it is used to format the url for the pill! Without it, we dont know where to send you :)');
+        alert('The formattedHitURL or onSelect props were not found, it is used to format the url for the pill! Without it, we dont know where to send you :)');
       }
 
       setEnterKeyWasPressed(false);
@@ -13200,7 +13211,8 @@ var ResultPill_ResultPill = function ResultPill(props) {
     onMouseEnter: handleHoverSelection
   }, emotion_react_browser_esm_jsx("a", {
     ref: clickableLink,
-    href: formattedHitURL,
+    href: !onSelect && formattedHitURL,
+    onClick: onSelect,
     className: "px-2 rounded outline-none ".concat(isCurrentElement ? 'bg-indigo-600 text-white' : 'text-gray-800'),
     style: ResultPill_objectSpread({}, ResultPill_style.resultPillLink)
   }, children));
@@ -13209,14 +13221,16 @@ var ResultPill_ResultPill = function ResultPill(props) {
 ResultPill_ResultPill.defaultProps = {
   elementIndex: null,
   sectionIndex: null,
-  noResults: false
+  noResults: false,
+  onSelect: null
 };
 ResultPill_ResultPill.propTypes = {
   children: prop_types_default.a.node.isRequired,
   elementIndex: prop_types_default.a.number,
   sectionIndex: prop_types_default.a.number,
   formattedHitURL: prop_types_default.a.string.isRequired,
-  noResults: prop_types_default.a.bool
+  noResults: prop_types_default.a.bool,
+  onSelect: prop_types_default.a.func
 };
 /* harmony default export */ var ResultsList_ResultPill = (ResultPill_ResultPill);
 // CONCATENATED MODULE: ./src/AlgoliaSearch/elements/ResultsList/SectionTitle/index.js
@@ -13252,11 +13266,13 @@ var ResultsList_ResultsList = function ResultsList(props) {
       sectionTitle = props.sectionTitle,
       sectionIndex = props.sectionIndex,
       renderCardInfo = props.renderCardInfo,
-      formatHitURL = props.formatHitURL;
+      formatHitURL = props.formatHitURL,
+      onSelect = props.onSelect;
 
   var _useTabController = TabController_useTabController(),
       appendNewSectionLength = _useTabController.appendNewSectionLength,
-      shouldHideResults = _useTabController.shouldHideResults;
+      shouldHideResults = _useTabController.shouldHideResults,
+      setIsResultsWindowOpen = _useTabController.setIsResultsWindowOpen;
 
   Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["useEffect"])(function () {
     if (hits.length > 0) {
@@ -13267,7 +13283,7 @@ var ResultsList_ResultsList = function ResultsList(props) {
   }, [hits.length]); // eslint-disable-line
 
   var formattedHitURL = Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["useCallback"])(function (hit) {
-    return formatHitURL(hit);
+    return formatHitURL ? formatHitURL(hit) : null;
   }, [formatHitURL]);
 
   if (Array.isArray(hits) && hits.length > 0 && !shouldHideResults) {
@@ -13280,7 +13296,11 @@ var ResultsList_ResultsList = function ResultsList(props) {
         key: index,
         elementIndex: index,
         sectionIndex: sectionIndex,
-        formattedHitURL: formattedHitURL(hit)
+        formattedHitURL: formattedHitURL(hit),
+        onSelect: onSelect ? function () {
+          onSelect(hit);
+          setIsResultsWindowOpen(false);
+        } : null
       }, renderCardInfo(hit));
     })));
   }
@@ -13293,7 +13313,7 @@ ResultsList_ResultsList.propTypes = {
   sectionTitle: prop_types_default.a.string.isRequired,
   sectionIndex: prop_types_default.a.number.isRequired,
   renderCardInfo: prop_types_default.a.func.isRequired,
-  formatHitURL: prop_types_default.a.func.isRequired
+  formatHitURL: prop_types_default.a.func
 };
 /* harmony default export */ var elements_ResultsList = (connectHits(ResultsList_ResultsList));
 // CONCATENATED MODULE: ./src/AlgoliaSearch/assets/ArrowDown/index.js
@@ -13469,7 +13489,9 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
       indexResultsLimit = props.indexResultsLimit,
       className = props.className,
       dark = props.dark,
-      placeholder = props.placeholder;
+      placeholder = props.placeholder,
+      formatSelected = props.formatSelected,
+      _onSelect = props.onSelect;
 
   var _useTabController = TabController_useTabController(),
       activeElementIndex = _useTabController.activeElementIndex,
@@ -13513,6 +13535,11 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
       _useState6 = SearchComponent_slicedToArray(_useState5, 2),
       isSearchEmpty = _useState6[0],
       setIsSearchEmpty = _useState6[1];
+
+  var _useState7 = Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["useState"])(),
+      _useState8 = SearchComponent_slicedToArray(_useState7, 2),
+      selectedItem = _useState8[0],
+      setSelectedItem = _useState8[1];
 
   var handleClickOutside = function handleClickOutside(e) {
     if (searchComponentRef.current.contains(e.target)) {
@@ -13649,6 +13676,8 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
 
       case 13:
         handleKeyNavigation(navigationKeyTypes.ENTER);
+        e.stopPropagation();
+        e.preventDefault();
         break;
 
       default:
@@ -13673,6 +13702,7 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
   }, emotion_react_browser_esm_jsx(elements_SearchBox, {
     id: ALGOLIA_APP_ID,
     dark: dark,
+    selectedText: selectedItem ? formatSelected(selectedItem) : '',
     placeholder: placeholder
   }), emotion_react_browser_esm_jsx("div", {
     className: "shadow-xl rounded absolute w-full bg-white border border-gray-200",
@@ -13702,7 +13732,11 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
       sectionTitle: displayName,
       renderCardInfo: renderCardInfo,
       sectionIndex: sectionIndex,
-      formatHitURL: formatHitURL
+      formatHitURL: formatHitURL,
+      onSelect: function onSelect(hit) {
+        setSelectedItem(hit);
+        _onSelect && _onSelect(hit);
+      }
     }));
   }), totalElementsCount === 0 && isSearchEmpty && NoResultsToRender, totalElementsCount === 0 && !isSearchEmpty && LoaderToRender), emotion_react_browser_esm_jsx(elements_Controls, null)))));
 };
@@ -13730,7 +13764,9 @@ SearchComponent_SearchComponent.propTypes = {
   scrollWindowHeight: prop_types_default.a.number,
   customLoader: prop_types_default.a.node,
   customNoResults: prop_types_default.a.node,
-  indexResultsLimit: prop_types_default.a.number.isRequired
+  indexResultsLimit: prop_types_default.a.number.isRequired,
+  onSelect: prop_types_default.a.func,
+  formatSelected: prop_types_default.a.func
 };
 /* harmony default export */ var elements_SearchComponent = (SearchComponent_SearchComponent);
 // CONCATENATED MODULE: ./src/AlgoliaSearch/index.js

--- a/dist/index.js
+++ b/dist/index.js
@@ -12939,8 +12939,6 @@ function _cleanUp(props, searchState, context) {
   }
 }));
 // CONCATENATED MODULE: ./src/AlgoliaSearch/elements/SearchBox/index.js
-function SearchBox_defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-
 function SearchBox_extends() { SearchBox_extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return SearchBox_extends.apply(this, arguments); }
 
 
@@ -12962,7 +12960,8 @@ var SearchBox_SearchBox = function SearchBox(props) {
       dark = props.dark,
       placeholder = props.placeholder,
       selectedText = props.selectedText,
-      inputProps = props.inputProps;
+      inputProps = props.inputProps,
+      onSelect = props.onSelect;
 
   var _useTabController = TabController_useTabController(),
       resetActiveElementIndex = _useTabController.resetActiveElementIndex,
@@ -12985,6 +12984,11 @@ var SearchBox_SearchBox = function SearchBox(props) {
       e.preventDefault();
     }
 
+    if (!(value === null || value === void 0 ? void 0 : value.length) && onSelect) {
+      // Trigger on Select when field clears
+      onSelect();
+    }
+
     setIsResultsWindowOpen(valHasLength(value));
   };
 
@@ -13005,18 +13009,18 @@ var SearchBox_SearchBox = function SearchBox(props) {
     className: "ais-SearchBox-form m-0",
     noValidate: true,
     role: "search"
-  }, emotion_react_browser_esm_jsx(src_Input, SearchBox_extends(SearchBox_defineProperty({
+  }, emotion_react_browser_esm_jsx(src_Input, SearchBox_extends({
     ref: inputRef,
     inputClassName: "".concat((isResultsWindowOpen ? "focused" : "", dark ? "bg-gray-800 border-gray-600 text-white focus:border-gray-500 hover:border-gray-500" : "bg-white border-gray-200 text-gray-900 focus:border-gray-300 hover:border-gray-300"), " -mt-1 ais-SearchBox-input w-full focus:outline-none focus:shadow-none"),
     value: currentRefinement,
     onChange: handleOnChange,
     onFocus: checkIfResultsWindowShouldOpen,
-    type: "search",
     "aria-label": "Search for a resource by typing here",
     placeholder: "".concat(placeholder ? placeholder : "Search..."),
     id: "search-box-".concat(id),
-    autoComplete: "off"
-  }, "type", "search"), inputProps))));
+    autoComplete: "off",
+    type: "search"
+  }, inputProps))));
 };
 
 SearchBox_SearchBox.propTypes = {
@@ -13205,7 +13209,7 @@ var ResultPill_ResultPill = function ResultPill(props) {
   }
 
   return emotion_react_browser_esm_jsx("li", {
-    className: "pb-1",
+    className: "mb-1",
     style: ResultPill_objectSpread({}, ResultPill_style.resultPill),
     tabIndex: 0,
     role: "option",
@@ -13495,7 +13499,7 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
       dark = props.dark,
       placeholder = props.placeholder,
       formatSelected = props.formatSelected,
-      _onSelect = props.onSelect,
+      onSelect = props.onSelect,
       inputProps = props.inputProps;
 
   var _useTabController = TabController_useTabController(),
@@ -13691,6 +13695,11 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
     }
   };
 
+  var handleOnSelect = function handleOnSelect(hit) {
+    setSelectedItem(hit);
+    onSelect && onSelect(hit);
+  };
+
   var LoaderToRender = customLoader ? customLoader : emotion_react_browser_esm_jsx(elements_Loader, null);
   var NoResultsToRender = customNoResults ? customNoResults : emotion_react_browser_esm_jsx(elements_NoResults, null);
   return emotion_react_browser_esm_jsx("div", {
@@ -13709,7 +13718,8 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
     dark: dark,
     selectedText: selectedItem ? formatSelected(selectedItem) : '',
     inputProps: inputProps,
-    placeholder: placeholder
+    placeholder: placeholder,
+    onSelect: handleOnSelect
   }), emotion_react_browser_esm_jsx("div", {
     className: "shadow-xl rounded absolute w-full bg-white border border-gray-200",
     style: {
@@ -13739,10 +13749,7 @@ var SearchComponent_SearchComponent = function SearchComponent(props) {
       renderCardInfo: renderCardInfo,
       sectionIndex: sectionIndex,
       formatHitURL: formatHitURL,
-      onSelect: function onSelect(hit) {
-        setSelectedItem(hit);
-        _onSelect && _onSelect(hit);
-      }
+      onSelect: handleOnSelect
     }));
   }), totalElementsCount === 0 && isSearchEmpty && NoResultsToRender, totalElementsCount === 0 && !isSearchEmpty && LoaderToRender), emotion_react_browser_esm_jsx(elements_Controls, null)))));
 };

--- a/src/AlgoliaSearch/algoliaSearch.stories.mdx
+++ b/src/AlgoliaSearch/algoliaSearch.stories.mdx
@@ -206,3 +206,32 @@ Use `scrollWindowHeight` to control the height of the results window
     </div>
   </Story>
 </Preview>
+
+# Selectable
+
+Pass the `onSelect` and `formatSelected` props so the AlgoliaSearch will become selectable.
+When setting AlgoliaSearch as selectable, it will ignore the `formatHitURL` prop.
+
+Disclaimer: AlgoliaSearch selectable mode is not yet tested with multiple indices.
+
+<Preview>
+  <Story name="Selectable">
+    <div style={{ height: "200px" }}>
+      <AlgoliaSearch
+        ALGOLIA_APP_ID="XWSX3ZKORI"
+        ALGOLIA_API_SEARCH_KEY="bc85ff85b128ba7dfc859b986cc9df21"
+        indices={[
+          {
+            indexName: "movies",
+            displayName: "Movies",
+            renderCardInfo: (data) => <Text color="white">{data.title}</Text>,
+          },
+        ]}
+        searchOperators={["<", "=", ">", ">=", "<="]}
+        specialChar=":"
+        formatSelected={(data) => data.title}
+        onSelect={(data) => console.log('SELECTED', data)}
+      />
+    </div>
+  </Story>
+</Preview>

--- a/src/AlgoliaSearch/algoliaSearch.stories.mdx
+++ b/src/AlgoliaSearch/algoliaSearch.stories.mdx
@@ -207,6 +207,34 @@ Use `scrollWindowHeight` to control the height of the results window
   </Story>
 </Preview>
 
+# Custom input props
+
+<Preview>
+  <Story name="Custom input props">
+    <div style={{ height: "200px" }}>
+      <AlgoliaSearch
+        ALGOLIA_APP_ID="XWSX3ZKORI"
+        ALGOLIA_API_SEARCH_KEY="bc85ff85b128ba7dfc859b986cc9df21"
+        indices={[
+          {
+            indexName: "movies",
+            displayName: "Movies",
+            renderCardInfo: (data) => <Text color="white">{data.title}</Text>,
+          },
+        ]}
+        searchOperators={["<", "=", ">", ">=", "<="]}
+        specialChar=":"
+        formatSelected={(data) => data.title}
+        onSelect={(data) => console.log('SELECTED', data)}
+        inputProps={{
+          label: 'Movie',
+          placeholder: 'Choose a movie...',
+        }}
+      />
+    </div>
+  </Story>
+</Preview>
+
 # Selectable
 
 Pass the `onSelect` and `formatSelected` props so the AlgoliaSearch will become selectable.

--- a/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
+++ b/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
@@ -12,6 +12,7 @@ const ResultPill = (props) => {
     sectionIndex,
     formattedHitURL,
     noResults,
+    onSelect,
   } = props;
 
   const {
@@ -37,8 +38,10 @@ const ResultPill = (props) => {
     if (isCurrentElement && enterKeyWasPressed) {
       if (formattedHitURL) {
         clickableLink.current.click();
+      } else if (onSelect) {
+        onSelect()
       } else {
-        alert('The formattedHitURL prop was not found, it is used to format the url for the pill! Without it, we dont know where to send you :)')
+        alert('The formattedHitURL or onSelect props were not found, it is used to format the url for the pill! Without it, we dont know where to send you :)')
       }
       setEnterKeyWasPressed(false);
     }
@@ -56,7 +59,7 @@ const ResultPill = (props) => {
       setScrollDistance(distToScroll);
     }
   }, [isCurrentElement, scrollableWindowHeight, scrollableWindowTopOffset, scrollWindowRef, setScrollDistance, setEnterKeyWasPressed, enterKeyWasPressed]);
-  
+
   const handleHoverSelection = () => {
     manuallySetActiveIndex((sectionLengthsArray[sectionIndex - 1] || 0) + elementIndex);
   }
@@ -95,7 +98,8 @@ const ResultPill = (props) => {
     >
       <a
         ref={clickableLink}
-        href={formattedHitURL}
+        href={!onSelect && formattedHitURL}
+        onClick={onSelect}
         className={`px-2 rounded outline-none ${isCurrentElement ? 'bg-indigo-600 text-white' : 'text-gray-800'}`}
         style={{...styles.resultPillLink}}
       >
@@ -109,6 +113,7 @@ ResultPill.defaultProps = {
   elementIndex: null,
   sectionIndex: null,
   noResults: false,
+  onSelect: null,
 };
 
 ResultPill.propTypes = {
@@ -117,6 +122,7 @@ ResultPill.propTypes = {
   sectionIndex: PropTypes.number,
   formattedHitURL: PropTypes.string.isRequired,
   noResults: PropTypes.bool,
+  onSelect: PropTypes.func,
 };
 
 export default ResultPill;

--- a/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
+++ b/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
@@ -88,7 +88,7 @@ const ResultPill = (props) => {
 
   return (
     <li
-      className="pb-1"
+      className="mb-1"
       style={{...styles.resultPill}}
       tabIndex={0}
       role="option"

--- a/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
+++ b/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
@@ -98,7 +98,7 @@ const ResultPill = (props) => {
     >
       <a
         ref={clickableLink}
-        href={!onSelect && formattedHitURL}
+        href={!onSelect ? formattedHitURL : null}
         onClick={onSelect}
         className={`px-2 rounded outline-none ${isCurrentElement ? 'bg-indigo-600 text-white' : 'text-gray-800'}`}
         style={{...styles.resultPillLink}}

--- a/src/AlgoliaSearch/elements/ResultsList/index.js
+++ b/src/AlgoliaSearch/elements/ResultsList/index.js
@@ -13,9 +13,10 @@ const ResultsList = (props) => {
     sectionIndex,
     renderCardInfo,
     formatHitURL,
+    onSelect,
   } = props;
 
-  const { appendNewSectionLength, shouldHideResults } = useTabController();
+  const { appendNewSectionLength, shouldHideResults, setIsResultsWindowOpen } = useTabController();
 
   useEffect(() => {
     if (hits.length > 0) {
@@ -26,7 +27,7 @@ const ResultsList = (props) => {
   }, [hits.length]); // eslint-disable-line
 
   const formattedHitURL = useCallback((hit) => {
-    return formatHitURL(hit)
+    return formatHitURL ? formatHitURL(hit) : null
   }, [formatHitURL]);
 
   if ((Array.isArray(hits) && hits.length > 0) && !shouldHideResults) {
@@ -42,6 +43,10 @@ const ResultsList = (props) => {
                   elementIndex={index}
                   sectionIndex={sectionIndex}
                   formattedHitURL={formattedHitURL(hit)}
+                  onSelect={onSelect ? () => {
+                    onSelect(hit)
+                    setIsResultsWindowOpen(false)
+                  } : null}
                 >
                   {renderCardInfo(hit)}
                 </ResultPill>
@@ -62,7 +67,8 @@ ResultsList.propTypes = {
   sectionTitle: PropTypes.string.isRequired,
   sectionIndex: PropTypes.number.isRequired,
   renderCardInfo: PropTypes.func.isRequired,
-  formatHitURL: PropTypes.func.isRequired,
+  formatHitURL: PropTypes.func,
+  onSelect: PropTypes.func,
 };
 
 export default connectHits(ResultsList);

--- a/src/AlgoliaSearch/elements/SearchBox/index.js
+++ b/src/AlgoliaSearch/elements/SearchBox/index.js
@@ -11,7 +11,7 @@ const valHasLength = (value) => {
 };
 
 const SearchBox = (props) => {
-  const { currentRefinement, refine, id, dark, placeholder, selectedText, inputProps } = props;
+  const { currentRefinement, refine, id, dark, placeholder, selectedText, inputProps, onSelect } = props;
 
   const {
     resetActiveElementIndex,
@@ -34,6 +34,11 @@ const SearchBox = (props) => {
       refine(value);
     } else {
       e.preventDefault();
+    }
+
+    if (!value?.length && onSelect) {
+      // Trigger on Select when field clears
+      onSelect()
     }
 
     setIsResultsWindowOpen(valHasLength(value));
@@ -64,7 +69,6 @@ const SearchBox = (props) => {
           value={currentRefinement}
           onChange={handleOnChange}
           onFocus={checkIfResultsWindowShouldOpen}
-          type="search"
           aria-label="Search for a resource by typing here"
           placeholder={`${placeholder ? placeholder : "Search..."}`}
           id={`search-box-${id}`}

--- a/src/AlgoliaSearch/elements/SearchBox/index.js
+++ b/src/AlgoliaSearch/elements/SearchBox/index.js
@@ -11,7 +11,7 @@ const valHasLength = (value) => {
 };
 
 const SearchBox = (props) => {
-  const { currentRefinement, refine, id, dark, placeholder } = props;
+  const { currentRefinement, refine, id, dark, placeholder, selectedText } = props;
 
   const {
     resetActiveElementIndex,
@@ -20,7 +20,13 @@ const SearchBox = (props) => {
     setSearchInputHeight,
   } = useTabController();
 
+  const inputRef = useRef()
   const searchInputRef = useRef(null);
+
+  useEffect(() => {
+    refine(selectedText)
+    inputRef.current.value = selectedText || ''
+  }, [selectedText])
 
   const handleOnChange = (value, e) => {
     if (e.keyCode !== 40 && e.keyCode !== 38) {
@@ -48,6 +54,7 @@ const SearchBox = (props) => {
     <div className="ais-SearchBox pb-2" ref={searchInputRef}>
       <form className="ais-SearchBox-form m-0" noValidate role="search">
         <Input
+          ref={inputRef}
           inputClassName={`${
             (isResultsWindowOpen ? "focused" : "",
             dark
@@ -73,6 +80,7 @@ SearchBox.propTypes = {
   currentRefinement: PropTypes.string.isRequired,
   refine: PropTypes.func.isRequired,
   id: PropTypes.string.isRequired,
+  selectedText: PropTypes.string,
 };
 
 export default connectSearchBox(SearchBox);

--- a/src/AlgoliaSearch/elements/SearchBox/index.js
+++ b/src/AlgoliaSearch/elements/SearchBox/index.js
@@ -11,7 +11,7 @@ const valHasLength = (value) => {
 };
 
 const SearchBox = (props) => {
-  const { currentRefinement, refine, id, dark, placeholder, selectedText } = props;
+  const { currentRefinement, refine, id, dark, placeholder, selectedText, inputProps } = props;
 
   const {
     resetActiveElementIndex,
@@ -70,6 +70,7 @@ const SearchBox = (props) => {
           id={`search-box-${id}`}
           autoComplete="off"
           type="search"
+          {...inputProps}
         />
       </form>
     </div>

--- a/src/AlgoliaSearch/elements/SearchComponent/index.js
+++ b/src/AlgoliaSearch/elements/SearchComponent/index.js
@@ -222,6 +222,11 @@ const SearchComponent = (props) => {
     }
   };
 
+  const handleOnSelect = (hit) => {
+    setSelectedItem(hit)
+    onSelect && onSelect(hit)
+  }
+
   const LoaderToRender = customLoader ? customLoader : <Loader />;
   const NoResultsToRender = customNoResults ? customNoResults : <NoResults />;
 
@@ -239,6 +244,7 @@ const SearchComponent = (props) => {
             selectedText={selectedItem ? formatSelected(selectedItem) : ''}
             inputProps={inputProps}
             placeholder={placeholder}
+            onSelect={handleOnSelect}
           />
 
           <div
@@ -272,10 +278,7 @@ const SearchComponent = (props) => {
                       renderCardInfo={renderCardInfo}
                       sectionIndex={sectionIndex}
                       formatHitURL={formatHitURL}
-                      onSelect={hit => {
-                        setSelectedItem(hit)
-                        onSelect && onSelect(hit)
-                      }}
+                      onSelect={handleOnSelect}
                     />
                   </Index>
                 );

--- a/src/AlgoliaSearch/elements/SearchComponent/index.js
+++ b/src/AlgoliaSearch/elements/SearchComponent/index.js
@@ -29,6 +29,7 @@ const SearchComponent = (props) => {
     placeholder,
     formatSelected,
     onSelect,
+    inputProps,
   } = props;
 
   const {
@@ -236,6 +237,7 @@ const SearchComponent = (props) => {
             id={ALGOLIA_APP_ID}
             dark={dark}
             selectedText={selectedItem ? formatSelected(selectedItem) : ''}
+            inputProps={inputProps}
             placeholder={placeholder}
           />
 

--- a/src/AlgoliaSearch/elements/SearchComponent/index.js
+++ b/src/AlgoliaSearch/elements/SearchComponent/index.js
@@ -27,6 +27,8 @@ const SearchComponent = (props) => {
     className,
     dark,
     placeholder,
+    formatSelected,
+    onSelect,
   } = props;
 
   const {
@@ -63,6 +65,7 @@ const SearchComponent = (props) => {
   const [filterState, setFilterState] = useState("");
   const [conditionalOperands, setConditionalOperands] = useState(null);
   const [isSearchEmpty, setIsSearchEmpty] = useState(false);
+  const [selectedItem, setSelectedItem] = useState()
 
   const handleClickOutside = (e) => {
     if (searchComponentRef.current.contains(e.target)) {
@@ -208,6 +211,8 @@ const SearchComponent = (props) => {
 
       case 13:
         handleKeyNavigation(navigationKeyTypes.ENTER);
+        e.stopPropagation()
+        e.preventDefault()
         break;
 
       default:
@@ -227,7 +232,12 @@ const SearchComponent = (props) => {
         onSearchStateChange={handleOnSearchStateChange}
       >
         <div onKeyDown={handleOnKeyDown} role="listbox" className="relative">
-          <SearchBox id={ALGOLIA_APP_ID} dark={dark} placeholder={placeholder} />
+          <SearchBox
+            id={ALGOLIA_APP_ID}
+            dark={dark}
+            selectedText={selectedItem ? formatSelected(selectedItem) : ''}
+            placeholder={placeholder}
+          />
 
           <div
             className="shadow-xl rounded absolute w-full bg-white border border-gray-200"
@@ -260,6 +270,10 @@ const SearchComponent = (props) => {
                       renderCardInfo={renderCardInfo}
                       sectionIndex={sectionIndex}
                       formatHitURL={formatHitURL}
+                      onSelect={hit => {
+                        setSelectedItem(hit)
+                        onSelect && onSelect(hit)
+                      }}
                     />
                   </Index>
                 );
@@ -306,6 +320,8 @@ SearchComponent.propTypes = {
   customLoader: PropTypes.node,
   customNoResults: PropTypes.node,
   indexResultsLimit: PropTypes.number.isRequired,
+  onSelect: PropTypes.func,
+  formatSelected: PropTypes.func,
 };
 
 export default SearchComponent;


### PR DESCRIPTION
Adds select ability for AlgoliaSearch, rather than just opening links. (Something similar to how the Request Additional IPs **device** input is used on the old Control).

This feature is intended to be used in Control for the Additional IPs form to search on devices. 

![Screenshot 2021-03-19 at 19 59 15](https://user-images.githubusercontent.com/11167320/111823531-baf24b80-88ed-11eb-80c3-c46a90bfebc0.png)

This PR also will allow sending custom input props rather than just placeholder. This will allow sending useful props when used in a form like `label`, `error`, etc. Question is if we should already remove the `placeholder` prop as that could be sent via `inputProps`.
![Screenshot 2021-03-19 at 20 23 53](https://user-images.githubusercontent.com/11167320/111826188-0e19cd80-88f1-11eb-9cf2-d4dfa44c4131.png)
