### PR TITLE
Fixes non-selectable handling AlgoliaSearch

### DIFF
--- a/src/AlgoliaSearch/elements/ResultsList/index.js
+++ b/src/AlgoliaSearch/elements/ResultsList/index.js
@@ -14,6 +14,7 @@ const ResultsList = (props) => {
     renderCardInfo,
     formatHitURL,
     onSelect,
+    isSelectable,
   } = props;
 
   const { appendNewSectionLength, shouldHideResults, setIsResultsWindowOpen } = useTabController();
@@ -43,7 +44,7 @@ const ResultsList = (props) => {
                   elementIndex={index}
                   sectionIndex={sectionIndex}
                   formattedHitURL={formattedHitURL(hit)}
-                  onSelect={onSelect ? () => {
+                  onSelect={isSelectable ? () => {
                     onSelect(hit)
                     setIsResultsWindowOpen(false)
                   } : null}

--- a/src/AlgoliaSearch/elements/SearchComponent/index.js
+++ b/src/AlgoliaSearch/elements/SearchComponent/index.js
@@ -53,6 +53,8 @@ const SearchComponent = (props) => {
 
   const algoliaClient = algoliasearch(ALGOLIA_APP_ID, ALGOLIA_API_SEARCH_KEY);
 
+  const isSelectable = Boolean(onSelect)
+
   const searchClient = {
     search(requests) {
       if (shouldBypassSearch === true) return null;
@@ -223,8 +225,10 @@ const SearchComponent = (props) => {
   };
 
   const handleOnSelect = (hit) => {
-    setSelectedItem(hit)
-    onSelect && onSelect(hit)
+    if (isSelectable) {
+      setSelectedItem(hit)
+      onSelect(hit)
+    }
   }
 
   const LoaderToRender = customLoader ? customLoader : <Loader />;
@@ -279,6 +283,7 @@ const SearchComponent = (props) => {
                       sectionIndex={sectionIndex}
                       formatHitURL={formatHitURL}
                       onSelect={handleOnSelect}
+                      isSelectable={isSelectable}
                     />
                   </Index>
                 );


### PR DESCRIPTION
Fixes an error where regular (non-selectable) AlgoliaSearch would crash when selecting an item.

![Screenshot 2021-03-25 at 20 22 17](https://user-images.githubusercontent.com/11167320/112523836-d6ef6480-8da7-11eb-9a62-973df706cf2d.png)
