### PR TITLE
fix: AlgoliaSearch - adds missing pill onClick

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -11101,7 +11101,8 @@ var ResultPill_ResultPill = function ResultPill(props) {
     onMouseEnter: handleHoverSelection
   }, Object(react_["jsx"])("a", {
     ref: clickableLink,
-    href: formattedHitURL,
+    href: !onSelect ? formattedHitURL : null,
+    onClick: onSelect,
     className: "px-2 rounded outline-none ".concat(isCurrentElement ? 'bg-accent-two text-foreground' : 'text-accent-eight'),
     style: ResultPill_objectSpread({}, ResultPill_style.resultPillLink)
   }, children));

--- a/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
+++ b/src/AlgoliaSearch/elements/ResultsList/ResultPill/index.js
@@ -98,7 +98,8 @@ const ResultPill = (props) => {
     >
       <a
         ref={clickableLink}
-        href={formattedHitURL}
+        href={!onSelect ? formattedHitURL : null}
+        onClick={onSelect}
         className={`px-2 rounded outline-none ${isCurrentElement ? 'bg-accent-two text-foreground' : 'text-accent-eight'}`}
         style={{...styles.resultPillLink}}
       >


### PR DESCRIPTION
Adds `onClick` back from AlgoliaSearch pill which somehow got removed in this PR - https://github.com/Maxihost/metal-ui/pull/173/files#

You can see here that with the current version, selecting an AlgoliaSearch result pill only works via enter, not also onClick:
https://dash-v2-m8g9oxm08-maxihost.vercel.app/daniels-team/daniels-frontend-workloads/networking/ips