### PR TITLE
Improves button loading colors and adds "inherit" & "dark" SpinningDots variants

### DIFF
--- a/__tests__/components/__snapshots__/button.test.js.snap
+++ b/__tests__/components/__snapshots__/button.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Snapshots/Components/Button Render button 1`] = `
 <button
-  className="Button border items-center flex font-medium rounded-lg focus:outline-none transition ease-in-out duration-150 justify-center max-w-full cursor-pointer border-transparent hover:border-accent-five text-white hover:text-foreground bg-foreground hover:bg-accent-two active:bg-foreground active:text-white px-5 h-9 leading-9 text-sm"
+  className="Button relative border items-center flex font-medium rounded-lg focus:outline-none transition ease-in-out duration-150 justify-center max-w-full cursor-pointer border-transparent hover:border-accent-five text-white hover:text-foreground bg-foreground hover:bg-accent-two active:bg-foreground active:text-white px-5 h-9 leading-9 text-sm"
   disabled={false}
   type="button"
 >

--- a/dist/index.js
+++ b/dist/index.js
@@ -6475,18 +6475,28 @@ var bind = __webpack_require__(4);
 var bind_default = /*#__PURE__*/__webpack_require__.n(bind);
 
 // CONCATENATED MODULE: ./src/SpinningDots/index.js
+function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from `css` function. It isn't supposed to be used directly (e.g. as value of the `className` prop), but rather handed to emotion so it can handle it (e.g. as value of `css` prop)."; }
 
 
 
 
 
-var SpinningDots_SpinningDots = function SpinningDots(_ref) {
-  var className = _ref.className,
-      variant = _ref.variant;
-  var i = classnames_default()("animate-pulse w-1.5 h-1.5 rounded-full", {
-    'bg-accent-three': variant === 'light',
-    'bg-accent-six': variant === 'default'
+
+
+var SpinningDots_ref =  true ? {
+  name: "10904xo",
+  styles: "border-width:3px"
+} : undefined;
+
+var SpinningDots_SpinningDots = function SpinningDots(_ref2) {
+  var className = _ref2.className,
+      variant = _ref2.variant;
+  var i = classnames_default()("animate-pulse h-0 w-0 rounded-full", {
+    'text-accent-six': variant === 'default',
+    'text-accent-three': variant === 'light',
+    'text-accent-eight': variant === 'dark'
   });
+  var iCss = SpinningDots_ref;
   return Object(react_["jsx"])("div", {
     className: classnames_default()("spinner inline p-0 h-auto w-full text-center", className)
   }, Object(react_["jsx"])("span", {
@@ -6495,22 +6505,25 @@ var SpinningDots_SpinningDots = function SpinningDots(_ref) {
     className: "flex w-full justify-around"
   }, Object(react_["jsx"])("i", {
     className: i,
+    css: iCss,
     style: {
       animationDelay: "-.2s"
     }
   }), Object(react_["jsx"])("i", {
     className: i,
+    css: iCss,
     style: {
       animationDelay: "-.1s"
     }
   }), Object(react_["jsx"])("i", {
-    className: i
+    className: i,
+    css: iCss
   }))));
 };
 
 SpinningDots_SpinningDots.propTypes = {
   className: prop_types_default.a.string,
-  variant: prop_types_default.a.oneOf(["default", "light"])
+  variant: prop_types_default.a.oneOf(["default", "inherit", "light", "dark"])
 };
 SpinningDots_SpinningDots.defaultProps = {
   variant: "default"
@@ -6561,7 +6574,7 @@ var Button_Button = function Button(_ref) {
     className: "flex ml-2"
   }, /*#__PURE__*/Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["cloneElement"])(iconAfter)));
 
-  var ButtonClasses = cx("Button border items-center flex font-medium rounded-lg focus:outline-none transition ease-in-out duration-150 justify-center max-w-full cursor-pointer", (_cx = {
+  var ButtonClasses = cx("Button relative border items-center flex font-medium rounded-lg focus:outline-none transition ease-in-out duration-150 justify-center max-w-full cursor-pointer", (_cx = {
     disabled: disabled
   }, Button_defineProperty(_cx, variant, Boolean(variant) && !disabled), Button_defineProperty(_cx, "px-5 h-9 leading-9 text-sm", !Boolean(block)), Button_defineProperty(_cx, "px-12 h10 leading-10 w-full", Boolean(block)), Button_defineProperty(_cx, "px-12 h-10 leading-10", Boolean(large)), _cx));
 
@@ -6584,7 +6597,7 @@ var Button_Button = function Button(_ref) {
     disabled: disabled || isLoading,
     className: ButtonClasses
   }, isLoading && Object(react_["jsx"])(src_SpinningDots, {
-    variant: "light",
+    variant: "inherit",
     className: "absolute"
   }), ButtonContent));
 };
@@ -12817,7 +12830,7 @@ function react_dropdown_menu_dist_index_module_u(){return(react_dropdown_menu_di
 // CONCATENATED MODULE: ./src/DropdownMenu/index.js
 
 
-function _EMOTION_STRINGIFIED_CSS_ERROR__() { return "You have tried to stringify object returned from `css` function. It isn't supposed to be used directly (e.g. as value of the `className` prop), but rather handed to emotion so it can handle it (e.g. as value of `css` prop)."; }
+function DropdownMenu_EMOTION_STRINGIFIED_CSS_ERROR_() { return "You have tried to stringify object returned from `css` function. It isn't supposed to be used directly (e.g. as value of the `className` prop), but rather handed to emotion so it can handle it (e.g. as value of `css` prop)."; }
 
 
 

--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -45,7 +45,7 @@ const Button = ({
   );
 
   const ButtonClasses = cx(
-    "Button border items-center flex font-medium rounded-lg focus:outline-none transition ease-in-out duration-150 justify-center max-w-full cursor-pointer",
+    "Button relative border items-center flex font-medium rounded-lg focus:outline-none transition ease-in-out duration-150 justify-center max-w-full cursor-pointer",
     {
       disabled: disabled,
       [variant]: Boolean(variant) && !disabled,
@@ -80,7 +80,7 @@ const Button = ({
           disabled={disabled || isLoading}
           className={ButtonClasses}
         >
-          {isLoading && <SpinningDots variant="light" className="absolute" />}
+          {isLoading && <SpinningDots variant="inherit" className="absolute" />}
           {ButtonContent}
         </button>
       )}

--- a/src/SpinningDots/index.js
+++ b/src/SpinningDots/index.js
@@ -1,12 +1,19 @@
 import React from "react";
 import PropTypes from "prop-types";
 import classNames from "classnames";
+import { css } from '@emotion/react';
 
 const SpinningDots = ({ className, variant }) => {
-  const i = classNames("animate-pulse w-1.5 h-1.5 rounded-full", {
-    'bg-accent-three': variant === 'light',
-    'bg-accent-six': variant === 'default',
-  });
+  const i = classNames("animate-pulse h-0 w-0 rounded-full", {
+      'text-accent-six': variant === 'default',
+      'text-accent-three': variant === 'light',
+      'text-accent-eight': variant === 'dark',
+    }
+  );
+
+  const iCss = css`
+    border-width: 3px;
+  `;
 
   return (
     <div
@@ -17,9 +24,9 @@ const SpinningDots = ({ className, variant }) => {
     >
       <span className="inline-flex relative align-middle h-2 text-center opacity-50 w-10">
         <div className="flex w-full justify-around">
-          <i className={i} style={{ animationDelay: "-.2s" }}></i>
-          <i className={i} style={{ animationDelay: "-.1s" }}></i>
-          <i className={i}></i>
+          <i className={i} css={iCss} style={{ animationDelay: "-.2s" }}></i>
+          <i className={i} css={iCss} style={{ animationDelay: "-.1s" }}></i>
+          <i className={i} css={iCss}></i>
         </div>
       </span>
     </div>
@@ -30,7 +37,9 @@ SpinningDots.propTypes = {
   className: PropTypes.string,
   variant: PropTypes.oneOf([
     "default",
+    "inherit",
     "light",
+    "dark",
   ]),
 };
 

--- a/src/SpinningDots/spinning-dts.stories.mdx
+++ b/src/SpinningDots/spinning-dts.stories.mdx
@@ -18,3 +18,29 @@ import SpinningDots from "./index";
     <SpinningDots variant="light" />
   </Story>
 </Preview>
+
+# Dark
+
+<Preview>
+  <Story name="Dark">
+    <SpinningDots variant="dark" />
+  </Story>
+</Preview>
+
+# Inherit
+
+Will inherit color from the closest parent
+
+<Preview>
+  <Story name="Inherit">
+    <div className="inline-flex mr-2 text-error">
+      <SpinningDots variant="inherit" />
+    </div>
+    <div className="inline-flex mr-2 text-success">
+      <SpinningDots variant="inherit" />
+    </div>
+    <div className="inline-flex mr-2 text-foreground">
+      <SpinningDots variant="inherit" />
+    </div>
+  </Story>
+</Preview>


### PR DESCRIPTION
Button loading state on _hover_ and _light_ variant is not ideal - the loading dots can be barely seen. So I've updated the SpinningDots component to be created out of border so it can inherit the text color from the Button.

**Previous loading button normal state:**
![Screenshot 2021-03-26 at 19 51 24](https://user-images.githubusercontent.com/11167320/112674599-cbb33c00-8e6e-11eb-8484-4f9b20e2e9f2.png)
**Previous loading button hover state:**
![Screenshot 2021-03-26 at 19 51 53](https://user-images.githubusercontent.com/11167320/112674606-cd7cff80-8e6e-11eb-8562-372a6d5c339c.png)
**New loading button normal state:**
![Screenshot 2021-03-26 at 19 52 57](https://user-images.githubusercontent.com/11167320/112674616-cfdf5980-8e6e-11eb-883a-c587a4d3995c.png)
**New loading button hover state:**
![Screenshot 2021-03-26 at 19 53 37](https://user-images.githubusercontent.com/11167320/112674627-d1108680-8e6e-11eb-83e4-6c534eba0cf5.png)

Also added the `relative` classname for the Button. Without it, the spinner wouldn't use the Button as the relative element for `w-full` and it would stretch way more than the Button width and would mess up the hover of nearby elements. Debug screenshot can be seen here - https://user-images.githubusercontent.com/11167320/112675302-aa9f1b00-8e6f-11eb-9500-f96baf9b552f.png