### PR TITLE
Sidesheet improvements

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7724,7 +7724,7 @@ var Sidesheet_Sidesheet = function Sidesheet(_ref2) {
     noPadding: true,
     flex: true,
     flexDirection: "col",
-    className: "h-full"
+    className: "overflow-visible"
   }, content)), action && Object(react_["jsx"])(src_Box, {
     flex: true,
     justifyContent: "evenly",

--- a/dist/index.js
+++ b/dist/index.js
@@ -7655,7 +7655,7 @@ var Sidesheet_Sidesheet = function Sidesheet(_ref2) {
       setTransition(false);
       transitionTimeout = setTimeout(function () {
         return setIsOpened(false);
-      }, 500);
+      }, 300);
     } else {
       setIsOpened(true);
       transitionTimeout = setTimeout(function () {
@@ -7686,14 +7686,14 @@ var Sidesheet_Sidesheet = function Sidesheet(_ref2) {
     onClick: function onClick() {
       return closeTransition();
     },
-    className: bind_default()("fixed z-50 inset-0 opacity-25 duration-300 delay-200 transition", {
+    className: bind_default()("fixed z-50 inset-0 opacity-25 duration-200 delay-100 transition", {
       "bg-accent-eight": transition,
       "bg-transparent": !transition
     })
   }), Object(react_["jsx"])("div", {
     ref: portal,
     style: {
-      transition: "transform .4s cubic-bezier(.3,0,0,1)",
+      transition: "transform .2s cubic-bezier(.3,0,0,1)",
       transform: transition ? "translateX(calc(100vw - ".concat(width, "px - 20px))") : "translateX(100vw)",
       top: 0,
       bottom: 0,

--- a/dist/index.js
+++ b/dist/index.js
@@ -7649,17 +7649,23 @@ var Sidesheet_Sidesheet = function Sidesheet(_ref2) {
       setTransition = _useState4[1];
 
   Object(external_root_React_commonjs2_react_commonjs_react_amd_react_["useEffect"])(function () {
+    var transitionTimeout;
+
     if (!isShown) {
       setTransition(false);
-      setTimeout(function () {
+      transitionTimeout = setTimeout(function () {
         return setIsOpened(false);
       }, 500);
     } else {
       setIsOpened(true);
-      setTimeout(function () {
+      transitionTimeout = setTimeout(function () {
         return setTransition(true);
       }, 100);
     }
+
+    return function () {
+      return clearTimeout(transitionTimeout);
+    };
   }, [isShown]);
 
   var closeTransition = function closeTransition() {

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -138,7 +138,7 @@ const Sidesheet = ({
               flexDirection="col"
               className="sidesheet-content relative overflow-y-auto flex-1 rounded"
             >
-              <Box noPadding flex flexDirection="col" className="h-full">
+              <Box noPadding flex flexDirection="col" className="overflow-visible">
                 {content}
               </Box>
             </Box>

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -62,13 +62,17 @@ const Sidesheet = ({
   const [transition, setTransition] = useState(false);
 
   useEffect(() => {
+    let transitionTimeout
+
     if (!isShown) {
       setTransition(false);
-      setTimeout(() => setIsOpened(false), 500);
+      transitionTimeout = setTimeout(() => setIsOpened(false), 500);
     } else {
       setIsOpened(true);
-      setTimeout(() => setTransition(true), 100);
+      transitionTimeout = setTimeout(() => setTransition(true), 100);
     }
+
+    return () => clearTimeout(transitionTimeout)
   }, [isShown]);
 
   const closeTransition = () => {

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -66,7 +66,7 @@ const Sidesheet = ({
 
     if (!isShown) {
       setTransition(false);
-      transitionTimeout = setTimeout(() => setIsOpened(false), 500);
+      transitionTimeout = setTimeout(() => setIsOpened(false), 300);
     } else {
       setIsOpened(true);
       transitionTimeout = setTimeout(() => setTransition(true), 100);
@@ -91,7 +91,7 @@ const Sidesheet = ({
           <div
             onClick={() => closeTransition()}
             className={classNames(
-              "fixed z-50 inset-0 opacity-25 duration-300 delay-200 transition",
+              "fixed z-50 inset-0 opacity-25 duration-200 delay-100 transition",
               {
                 "bg-accent-eight": transition,
                 "bg-transparent": !transition,
@@ -101,7 +101,7 @@ const Sidesheet = ({
           <div
             ref={portal}
             style={{
-              transition: `transform .4s cubic-bezier(.3,0,0,1)`,
+              transition: `transform .2s cubic-bezier(.3,0,0,1)`,
               transform: transition
                 ? `translateX(calc(100vw - ${width}px - 20px))`
                 : `translateX(100vw)`,


### PR DESCRIPTION
1. Fixes Sidesheet breaking when opening within 500ms after the initial load. The `setIsOpen(false)` from the timeout would've been called after the `setIsOpen(true)` after changing the `isShown` value from the initial `false` to `true`. The old timeouts are now cleared after each `isShown` change in the `useEffect` hook.
2. Receiving a feedback from @fmluizao about the Sidesheet feeling slow, I bumped the panel animation from 0.4s to 0.2s and the background from 0.3s (+ 0.2s delay) to 0.2s (+ 0.1s delay). Screen recordings for comparison: - https://www.dropbox.com/sh/9oe2cqqpcld6brn/AAAq8N6U2CDYpJxT0pZaqsxoa?dl=0
3. Makes Sidesheet content scrollable 