### PR TITLE
chore: Release v3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# [3.8.0](https://github.com/Maxihost/metal-ui/compare/v3.7.1...v3.8.0) (2021-12-10)
+# [3.10.0](https://github.com/Maxihost/metal-ui/compare/v3.7.1...v3.10.0) (2021-12-10)
 
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@maxihost/metal-ui",
-  "version": "3.8.0",
+  "version": "3.10.0",
   "description": "Metal UI Design System",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
Some versions numbers were released on the next branch.
So we need to skip some minor versions for semantic release to work correctly.
This was done by tagging a commit as v3.10.0 so that semantic release can pick up the next version number.