### PR TITLE
Fix/spread props on radio components

### DIFF
--- a/src/RadioGroup/index.js
+++ b/src/RadioGroup/index.js
@@ -47,6 +47,9 @@ const StyledIndicator = styled(RadioGroupPrimitive.Indicator)(() => {
   const { variant, disabled } = useRadioGroup();
   const bg = () => {
     if (disabled) {
+      if (variant === "card") {
+        return tw`bg-accent-three`;
+      }
       return tw`bg-accent-four`;
     } if (variant === "card") {
       return tw`bg-brand-uv`;
@@ -76,8 +79,12 @@ const RadioGroupIndicator = () => {
 
 
 
-const RadioGroupTitle = ({ children, asLabel, htmlFor }) => {
-  const style = tw`block text-sm leading-4 font-medium`;
+const RadioGroupTitle = ({ children, asLabel, htmlFor, ...props }) => {
+  const { variant } = useRadioGroup();
+  const style = [
+    tw`block text-sm font-medium`,
+    variant === "default" && tw`leading-4`,
+  ];
   const RadioGroupTitleLabel = styled(Label.Root)(() => [
     style
   ]);
@@ -86,14 +93,14 @@ const RadioGroupTitle = ({ children, asLabel, htmlFor }) => {
   ]);
 
   if (asLabel) {
-    return <RadioGroupTitleLabel htmlFor={htmlFor}>{children}</RadioGroupTitleLabel>;
+    return <RadioGroupTitleLabel htmlFor={htmlFor} {...props}>{children}</RadioGroupTitleLabel>;
   }
-  return <RadioGroupTitleText>{children}</RadioGroupTitleText>;
+  return <RadioGroupTitleText {...props}>{children}</RadioGroupTitleText>;
 };
 
-const RadioGroupDescription = styled.div(() => [
-  tw`block mt-1 text-sm text-accent-four`,
-]);
+const RadioGroupDescription = ({ children, ...props }) => (
+  <div css={tw`block mt-1 text-sm text-accent-four`} {...props}> {children} </div>
+);
 
 
 const RadioGroupContext = createContext();
@@ -112,7 +119,7 @@ const RadioGroup = ({ children, showIndicator, collapsed, defaultValue, ...props
       ...props,
       showIndicator,
       defaultValue,
-      collapsed: collapsed
+      collapsed
     }}>
     <StyledRadioGroup defaultValue={defaultValue} {...props}>
       {children}

--- a/src/RadioGroup/index.js
+++ b/src/RadioGroup/index.js
@@ -1,79 +1,82 @@
-import React, {createContext, useContext}  from "react";
+import React, { createContext, useContext } from "react";
 import PropTypes from "prop-types";
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
 import * as Label from "@radix-ui/react-label";
-import tw, { styled , css} from "twin.macro";
+import tw, { styled, css } from "twin.macro";
 import { Check } from "heroicons-react";
 
 const StyledRadioGroup = styled(RadioGroupPrimitive.Root)(() => {
   const { display, collapsed } = useRadioGroup();
-  
+
   return [
     display === "list" && tw`flex flex-col gap-3`,
-    display === "grid" && tw`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4`, 
+    display === "grid" && tw`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4`,
     collapsed && css`grid-gap: 1px`,
   ];
 });
 
-const StyledItem = styled(RadioGroupPrimitive.Item)(( { disabled }) => {
+const StyledItem = styled(RadioGroupPrimitive.Item)(({ disabled }) => {
   const { variant, collapsed } = useRadioGroup();
   return [
     tw`relative flex gap-2 cursor-pointer focus:outline-none text-left text-accent-seven w-full`,
     disabled && tw`text-accent-four cursor-default`,
     variant === "card" &&
-    tw`w-full px-6 py-4 items-center justify-between bg-white`, 
+    tw`w-full px-6 py-4 items-center justify-between bg-white`,
     variant === "card" && collapsed &&
-    css`box-shadow: 0 0 0 1px rgb(234, 234, 234);`, 
+    css`box-shadow: 0 0 0 1px rgb(234, 234, 234);`,
     variant === "card" && !collapsed &&
-    tw`rounded shadow-sm border-border border`, 
+    tw`rounded shadow-sm border-border border`,
     variant === "card" && !disabled &&
-  tw`hover:bg-accent-two`, 
-    css`&[data-state="checked"] {  ${variant === "card" && tw`bg-accent-two ring-2 ring-offset-2 ring-inset ring-offset-brand-uv ring-white` }  }`
-  ];}
+    tw`hover:bg-accent-two`,
+    css`&[data-state="checked"] {  ${variant === "card" && tw`bg-accent-two ring-2 ring-offset-2 ring-inset ring-offset-brand-uv ring-white`}  }`
+  ];
+}
 );
 
 const StyledIndicatorWrapper = styled.div(() => {
-  const { variant} = useRadioGroup();
+  const { variant } = useRadioGroup();
   return [
     tw`flex items-center justify-center flex-shrink-0 rounded-full focus:outline-none`,
     variant === "card" ?
       tw`w-6 h-6 order-last`
       :
       tw`w-4 h-4 border border-accent-three`
-  ];});
+  ];
+});
 const StyledIndicator = styled(RadioGroupPrimitive.Indicator)(() => {
-  const { variant, disabled} = useRadioGroup();
+  const { variant, disabled } = useRadioGroup();
   const bg = () => {
-    if ( disabled ) {
+    if (disabled) {
       return tw`bg-accent-four`;
-    }  if ( variant === "card") {
+    } if (variant === "card") {
       return tw`bg-brand-uv`;
     }
     return tw`bg-foreground`;
   };
   return [
-    css`[data-state="unchecked"] & {  ${tw`hidden` }  }`,
+    css`[data-state="unchecked"] & {  ${tw`hidden`}  }`,
     tw`flex items-center justify-center rounded-full`,
     bg,
     variant === "card" ?
       tw`w-6 h-6 text-white`
       :
       tw`w-2 h-2`,
-  ];}
+  ];
+}
 );
 
 
 const RadioGroupIndicator = () => {
   const { variant } = useRadioGroup();
   return <StyledIndicatorWrapper>
-    <StyledIndicator> {variant === "card" && <Check className="h-4 w-4"/>} 
+    <StyledIndicator> {variant === "card" && <Check className="h-4 w-4" />}
     </StyledIndicator>
-  </StyledIndicatorWrapper>; 
+  </StyledIndicatorWrapper>;
 };
 
 
- 
-const RadioGroupTitle = ({children, asLabel, htmlFor}) => {
+
+const RadioGroupTitle = ({ children, asLabel, htmlFor }) => {
   const style = tw`block text-sm leading-4 font-medium`;
   const RadioGroupTitleLabel = styled(Label.Root)(() => [
     style
@@ -81,12 +84,12 @@ const RadioGroupTitle = ({children, asLabel, htmlFor}) => {
   const RadioGroupTitleText = styled.div(() => [
     style
   ]);
- 
+
   if (asLabel) {
     return <RadioGroupTitleLabel htmlFor={htmlFor}>{children}</RadioGroupTitleLabel>;
   }
   return <RadioGroupTitleText>{children}</RadioGroupTitleText>;
-};    
+};
 
 const RadioGroupDescription = styled.div(() => [
   tw`block mt-1 text-sm text-accent-four`,
@@ -94,7 +97,7 @@ const RadioGroupDescription = styled.div(() => [
 
 
 const RadioGroupContext = createContext();
- 
+
 function useRadioGroup() {
   const context = useContext(RadioGroupContext);
   if (context === undefined) {
@@ -103,26 +106,26 @@ function useRadioGroup() {
   return context;
 }
 
-const RadioGroup = ({children, showIndicator, collapsed, defaultValue,  ...props}) => {
-  return <RadioGroupContext.Provider 
+const RadioGroup = ({ children, showIndicator, collapsed, defaultValue, ...props }) => {
+  return <RadioGroupContext.Provider
     value={{
-      ...props, 
-      showIndicator, 
+      ...props,
+      showIndicator,
       defaultValue,
       collapsed: collapsed
-    }}> 
+    }}>
     <StyledRadioGroup defaultValue={defaultValue} {...props}>
       {children}
     </StyledRadioGroup>
   </RadioGroupContext.Provider>;
 };
 
-const RadioGroupItem = ({children, value, disabled,  ...props }) => {
+const RadioGroupItem = ({ children, value, disabled, ...props }) => {
   const { showIndicator, disabled: disabledGroup } = useRadioGroup();
-  return <StyledItem value={value} disabled={disabled || disabledGroup} {...props}> 
+  return <StyledItem value={value} disabled={disabled || disabledGroup} {...props}>
     {showIndicator && <RadioGroupIndicator />}
     <Label.Root className="grow w-full">
-      {children} 
+      {children}
     </Label.Root>
   </StyledItem>;
 };
@@ -145,7 +148,7 @@ RadioGroup.propTypes = {
   onValueChange: PropTypes.func,
   /**
      * Only effective for `grid` display 
-  */ 
+  */
   collapsed: PropTypes.bool,
   /**
      * Only effective for `card` variation 


### PR DESCRIPTION
This PR simply adds support to `...props` on `RadioGroupTitle` and `RadioGroupDescription` , so we can use `classNames` on them.
Also fixes linting problems