### PR TITLE
fix: Sidesheet vertical scroll

### DIFF
--- a/src/Box/index.js
+++ b/src/Box/index.js
@@ -28,6 +28,7 @@ const Box = ({
         overflow === 'overflow-clip' && tw`overflow-clip`,
         overflow === 'overflow-visible' && tw`overflow-visible`,
         overflow === 'overflow-scroll' && tw`overflow-scroll`,
+        overflow === 'overflow-y-auto' && tw`overflow-y-auto`,
 
         Boolean(flex) && tw`flex`,
         !Boolean(backgroundColor) && tw`bg-white`,

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -142,7 +142,7 @@ const Sidesheet = ({
               flex
               flexDirection="col"
               overflow={"overflow-y-auto"}
-              className="sidesheet-content relative overflow-y-auto flex-1 rounded"
+              className="sidesheet-content relative flex-1 rounded"
             >
               <Box
                 noPadding

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -141,15 +141,17 @@ const Sidesheet = ({
             <Box
               flex
               flexDirection="col"
+              overflow={"overflow-y-auto"}
               className="sidesheet-content relative overflow-y-auto flex-1 rounded"
             >
               <Box
                 noPadding
                 flex
                 flexDirection="col"
+                overflow={"overflow-y-auto"}
                 className="overflow-visible"
               >
-                {content}
+               <div className="flex-shrink-0">{content}</div>
               </Box>
             </Box>
             {action && (

--- a/src/Sidesheet/sidesheet.stories.mdx
+++ b/src/Sidesheet/sidesheet.stories.mdx
@@ -62,3 +62,29 @@ import Text from "../Text";
     }}
   </Story>
 </Preview>
+
+# With Long Content
+
+<Preview>
+  <Story name="With Long Content">
+    {() => {
+      const [isShown, setIsShown] = useState(false);
+      return (
+        <Sidesheet
+          title={"Title"}
+          onClose={() => setIsShown(false)}
+          isShown={isShown}
+          content={
+            <div style={{ height: "105vh" }}> Box with long content</div>
+          }
+        >
+          <Button
+            type="secondary"
+            onClick={() => setIsShown(true)}
+            label="Open Sidesheet"
+          />
+        </Sidesheet>
+      );
+    }}
+  </Story>
+</Preview>


### PR DESCRIPTION
This PR fixes the vertical scroll for `Sidesheet` component. 
Previously, despite classes being set intentionally to allow content scroll, in practice they weren't working because there was an overwriting happening on the `Box` component. This component actually required the `overflow` style to be set by an specific `prop`.  

I have created a `<Preview />` with example of overflowing content. 