### PR TITLE
fix: Sidesheet scrollbar, textarea resize and button label proptype

### DIFF
--- a/src/Button/index.js
+++ b/src/Button/index.js
@@ -79,7 +79,7 @@ Button.propTypes = {
   className: PropTypes.string,
   iconBefore: PropTypes.element,
   iconAfter: PropTypes.element,
-  label: PropTypes.string,
+  label: PropTypes.node,
   onClick: PropTypes.func,
   type: PropTypes.string,
   variant: PropTypes.oneOf([

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -142,14 +142,15 @@ const Sidesheet = ({
               flex
               flexDirection="col"
               overflow={"overflow-y-auto"}
-              className="sidesheet-content relative flex-1 rounded"
+              className="sidesheet-content relative flex-1 rounded px-3 py-3"
+              noPadding
             >
               <Box
                 noPadding
                 flex
                 flexDirection="col"
                 overflow={"overflow-y-auto"}
-                className="overflow-visible"
+                className="overflow-visible px-3 py-3"
               >
                <div className="flex-shrink-0">{content}</div>
               </Box>

--- a/src/Textarea/index.js
+++ b/src/Textarea/index.js
@@ -70,7 +70,7 @@ const Textarea = React.forwardRef(
             variant === "brand-dark" &&
               !disabled &&
               tw`border-transparent text-white bg-brand-melrose bg-opacity-20 placeholder-brand-melrose hocus:(border-transparent bg-opacity-30)`,
-            resize && tw`resize-none`
+            !resize && tw`resize-none`
           ]}
           {...rest}
         />
@@ -80,7 +80,7 @@ const Textarea = React.forwardRef(
 );
 
 Textarea.defaultProps = {
-  resize: true,
+  resize: false,
   rows: 3,
 };
 


### PR DESCRIPTION
This PR:
- Allows buttons to have icons as labels.
- Fixes the resize prop for Textarea.
- Adds some right padding to scrollbar content for some spacing between the content and scrollbar.