### PR TITLE
fix: Sidesheet - faster transition and support for reduced motion

### DIFF
--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -67,7 +67,7 @@ const Sidesheet = ({
 
     if (!isShown) {
       setTransition(false);
-      transitionTimeout = setTimeout(() => setIsOpened(false), 300);
+      transitionTimeout = setTimeout(() => setIsOpened(false), 100);
     } else {
       setIsOpened(true);
       transitionTimeout = setTimeout(() => setTransition(true), 100);
@@ -81,7 +81,7 @@ const Sidesheet = ({
     if (isOpened && transition) {
       onClose();
       setTransition(false);
-      timeout = setTimeout(() => setIsOpened(false), 300);
+      timeout = setTimeout(() => setIsOpened(false), 100);
     }
     return () => clearTimeout(timeout)
   };
@@ -96,7 +96,7 @@ const Sidesheet = ({
             <div
               onClick={isOpened ?  () => closeTransition() : null}
               css={[
-                tw`fixed z-50 inset-0 opacity-25 duration-200 transition`,
+                tw`fixed z-50 inset-0 opacity-25 duration-100 transition`,
                 transition && tw`bg-accent-eight`,
                 !transition && tw`bg-transparent`,
               ]}

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -96,7 +96,7 @@ const Sidesheet = ({
             <div
               onClick={isOpened ?  () => closeTransition() : null}
               css={[
-                tw`fixed z-50 inset-0 opacity-25 duration-200 delay-100 transition`,
+                tw`fixed z-50 inset-0 opacity-25 duration-200 transition`,
                 transition && tw`bg-accent-eight`,
                 !transition && tw`bg-transparent`,
               ]}

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -3,7 +3,8 @@ import { createPortal } from "react-dom";
 import PropTypes from "prop-types";
 import Box from "../Box";
 import { useKeyPressEvent } from "react-use";
-import tw from "twin.macro";
+import tw, { css } from "twin.macro";
+
 
 function XIcon() {
   return (
@@ -103,15 +104,21 @@ const Sidesheet = ({
             <div
               ref={portal}
               style={{
-                transform: transition
-                  ? `translateX(0)`
-                  : "translateX(100%)",
                 width: width,
                 maxWidth: "calc(100vw - 20px)",
                 height: "calc(100% - 20px)",
               }}
-              tw="fixed right-0 top-0 bottom-0 z-50 min-w-0 bg-white transition-transform duration-100  motion-reduce:transition-none h-full flex flex-col shadow-xl m-2 rounded"
-            >
+              css={[
+                css`
+                  transform: translateX(${ transition ? '0' : '100%' })
+                `,
+                css`
+                @media (prefers-reduced-motion) {
+                  transform: none;
+                  opacity: ${ transition ? '1' : '0' }
+                }`,
+                tw`fixed right-0 top-0 bottom-0 z-50 min-w-0 bg-white duration-100 h-full flex flex-col shadow-xl m-2 rounded transition-transform  motion-reduce:transition-opacity`
+              ]}>
               <Box
                 flex
                 alignItems="center"

--- a/src/Sidesheet/index.js
+++ b/src/Sidesheet/index.js
@@ -103,18 +103,14 @@ const Sidesheet = ({
             <div
               ref={portal}
               style={{
-                transition: "transform .2s cubic-bezier(.3,0,0,1)",
                 transform: transition
                   ? `translateX(0)`
                   : "translateX(100%)",
-                top: 0,
-                bottom: 0,
-                right:0,
                 width: width,
                 maxWidth: "calc(100vw - 20px)",
                 height: "calc(100% - 20px)",
               }}
-              tw="fixed z-50 min-w-0 bg-white duration-300 delay-200 h-full flex flex-col shadow-xl m-2 rounded"
+              tw="fixed right-0 top-0 bottom-0 z-50 min-w-0 bg-white transition-transform duration-100  motion-reduce:transition-none h-full flex flex-col shadow-xl m-2 rounded"
             >
               <Box
                 flex


### PR DESCRIPTION
- Makes Sidesheet entry transition faster 
- Removes transition for users with reduced motion turned on

Tip: to simulate reduced motion on Chrome, `cmd + shift + p` and search for "prefers-reduced-motion"

<img width="685" alt="Screenshot 2022-10-05 at 17 06 29" src="https://user-images.githubusercontent.com/101582143/194155909-88f0a7ed-df2e-4a10-98e7-707cb5128bc7.png">
